### PR TITLE
body-handler: fix :string conversion support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 /.nrepl-port
+/.lein-failures

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [exoscale/ex-http "0.3.15"]
                  [cc.qbits/auspex "0.1.0-alpha4"]
                  [cc.qbits/commons "1.0.0-alpha3"]]
-  :profiles {:dev  {:dependencies []}
+  :profiles {:dev  {:dependencies [[ring/ring-jetty-adapter    "1.7.1"]]}
              :test {:dependencies []}}
   :plugins [[lein-cljfmt "0.7.0"]]
   :cljfmt {:remove-multiple-non-indenting-spaces? true}

--- a/src/exoscale/telex/response.clj
+++ b/src/exoscale/telex/response.clj
@@ -2,7 +2,8 @@
   (:import (java.net.http HttpResponse
                           HttpResponse$BodyHandlers
                           HttpResponse$BodyHandler
-                          HttpResponse$BodyHandlers)))
+                          HttpResponse$BodyHandlers)
+           java.nio.charset.Charset))
 
 (defprotocol Response
   (status [http-response] "Returns http status of underlying response")
@@ -29,7 +30,7 @@
 (defmethod body-handler :string
   [{:exoscale.telex.response.body-handler/keys [charset]
     :or {charset "UTF-8"}}]
-  (HttpResponse$BodyHandlers/ofString charset))
+  (HttpResponse$BodyHandlers/ofString (Charset/forName charset)))
 
 (defmethod body-handler :byte-array
   [_ctx]

--- a/test/exoscale/telex/mocks.clj
+++ b/test/exoscale/telex/mocks.clj
@@ -1,0 +1,10 @@
+(ns exoscale.telex.mocks
+  (:require [ring.adapter.jetty             :refer [run-jetty]]))
+
+(defmacro with-server
+  [port handler & body]
+  `(let [server# (run-jetty ~handler {:port ~port :join? false})]
+     (try
+       ~@body
+       (finally
+         (.stop server#)))))


### PR DESCRIPTION
Using `:exoscale.telex.response/body-handler :string` used to throw an exception because it cannot convert String (defined charset) into a `java.nio.charset.Charset`
I am converting configured charset into `java.nio.charset.Charset` via `java.nio.charset.Charset/forName`