### PR TITLE
default to http 1.1

### DIFF
--- a/src/exoscale/telex/client.clj
+++ b/src/exoscale/telex/client.clj
@@ -59,7 +59,7 @@
 
 (def default-options
   #:exoscale.telex.client{:follow-redirects :normal
-                          :version :http-2})
+                          :version :http-1-1})
 
 (defn build [{:as options}]
   (let [b (HttpClient/newBuilder)]


### PR DESCRIPTION
since goaway support is missing it makes http 2 support a bit lacking -> default to 1.1 to avoid suprises.