### PR TITLE
simplify ring1

### DIFF
--- a/src/exoscale/telex/interceptor/ring1.clj
+++ b/src/exoscale/telex/interceptor/ring1.clj
@@ -6,61 +6,55 @@
   (:import (java.net.http HttpRequest
                           HttpResponse)))
 
+(def ring-keys [:url :body :method :query :headers :url
+                ;; exts
+                :form-params :query-params])
+
 (defn- ring1->http-request
   ^HttpRequest
-  [{:ring1.request/keys [url query method body headers]
-    :exoscale.telex.request/keys [timeout version expect-continue?]
-    :or {method :get}}]
+  [{{:keys [url query method body headers] :or {method :get}} :ring/request
+    :exoscale.telex.request/keys [timeout version expect-continue?]}]
   (request/http-request url query method body headers timeout version
                         expect-continue?))
 
 (defn- http-response->ring1
   [^HttpResponse http-response]
-  {:ring1.response/status (response/status http-response)
-   :ring1.response/body (response/body http-response)
-   :ring1.response/headers (response/headers->map http-response)})
+  {:status (response/status http-response)
+   :body (response/body http-response)
+   :headers (response/headers->map http-response)})
 
 (def ring-format-interceptor
   {:name ::map-format-interceptor
    :enter (fn [ctx]
-            (->> ctx
-                 (reduce-kv (fn [m k v]
-                              (assoc! m
-                                      (if (namespace k)
-                                        k
-                                        (keyword "ring1.request" (name k)))
-                                      v))
-                            (transient {}))
-                 (persistent!)))
+            (-> (apply dissoc ctx ring-keys)
+                (assoc :ring/request (select-keys ctx ring-keys))))
    :leave (fn [ctx]
-            (->> ctx
-                 (reduce-kv (fn [m k v]
-                              (cond-> m
-                                (= (namespace k) "ring1.response")
-                                (assoc! (keyword (name k)) v)))
-                            (transient ctx))
-                 (persistent!)))})
+            (-> ctx
+                (dissoc :ring/response :ring/request)
+                (conj (:ring/response ctx))))})
 
 (def request-interceptor
   {:name ::request
    :enter (fn [ctx]
             (assoc ctx :exoscale.telex/request (ring1->http-request ctx)))
    :leave (fn [ctx]
-            (into ctx (http-response->ring1 (:exoscale.telex/response ctx))))})
+            (assoc ctx
+                   :ring/response
+                   (http-response->ring1 (:exoscale.telex/response ctx))))})
 
 (def query-params-interceptor
   {:name ::query-params
    :enter
    (-> interceptor/encode-query-params
-       (ix/in [:ring1.request/query-params])
-       (ix/out [:ring1.request/query]))})
+       (ix/in [:ring/request :query-params])
+       (ix/out [:ring/request :query]))})
 
 (def form-params-interceptor
   {:name ::form-params
    :enter (-> interceptor/encode-query-params
-              (ix/in [:ring1.request/form-params])
-              (ix/out [:ring1.request/body])
-              (ix/when (fn [{:ring1.request/keys [form-params body]}]
+              (ix/in [:ring/request :form-params])
+              (ix/out [:ring/request :body])
+              (ix/when (fn [{{:keys [form-params body]} :ring/request}]
                          (and (not body)
                               (seq form-params)))))})
 

--- a/src/exoscale/telex/interceptor/ring1.clj
+++ b/src/exoscale/telex/interceptor/ring1.clj
@@ -6,6 +6,10 @@
   (:import (java.net.http HttpRequest
                           HttpResponse)))
 
+(def request-keys [:url :body :method :query :headers :url
+                   ;; exts
+                   :form-params :query-params])
+
 (defn- ring1->http-request
   ^HttpRequest
   [{:ring/keys [request]
@@ -24,14 +28,8 @@
   {:name ::map-format-interceptor
    :enter (fn [ctx]
             ;; we consider all non ns keys, ring-keys
-            (let [request-keys (reduce-kv (fn [m k v]
-                                            (cond-> m
-                                              (not (namespace k))
-                                              (assoc k v)))
-                                          {}
-                                          ctx)]
-              (-> (apply dissoc ctx (keys request-keys))
-                  (assoc :ring/request request-keys))))
+            (-> (apply dissoc ctx request-keys)
+                (assoc :ring/request (select-keys ctx request-keys))))
    :leave (fn [{:as ctx :ring/keys [response]}]
             ;; we just care about the final request output, hide
             ;; original request from potential output

--- a/src/exoscale/telex/interceptor/ring1.clj
+++ b/src/exoscale/telex/interceptor/ring1.clj
@@ -32,15 +32,12 @@
                                           ctx)]
               (-> (apply dissoc ctx (keys request-keys))
                   (assoc :ring/request request-keys))))
-   :leave (fn [{:as ctx :ring/keys [request response]}]
+   :leave (fn [{:as ctx :ring/keys [response]}]
             ;; we just care about the final request output, hide
-            ;; original request for potential output, put it in meta
-            ;; instead (prevent potential POST secrets leaking in
-            ;; logs)
+            ;; original request from potential output
             (-> ctx
                 (dissoc :ring/response :ring/request)
-                (conj response)
-                (vary-meta assoc :ring/request request)))})
+                (conj response)))})
 
 (def request-interceptor
   {:name ::request


### PR DESCRIPTION
This only impacts the internals of the ring1 interceptors: 
Right now we duplicate some keys from original user input to internal representations, this is especially problematic for request keys, since we might output a whole ctx in the logs that could include it, in theory for a POST request we could potentially leak (signed) credentials data into logs. 

This PR simplifies the ring1 interceptors and makes it that once we negotiated a response we throw away the original request input from the context (it's still recoverable by hitting the exoscale.telex/request (the java instance), and extracting request fields manually, but it's not exposed to logs when "printing").