### PR TITLE
add body handler read timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Response options:
 
 * `:exoscale.telex.response/body-handler`
 * `:exoscale.telex.response/executor`
+* `:exoscale.telex.response.body-handler/timeout` dicts how long a
+  bodyhandler will try to get data from the response until triggering
+  a java.net.http.HttpTimeoutException. default to 10s. This will only
+  be tested if/when you start consuming the body.
 
 Body handler options are in `exoscale.telex.response`, some
 of them can also take extra arguments:
@@ -79,7 +83,6 @@ of them can also take extra arguments:
 `:input-stream` `:publisher` `:byte-array-consumer` `:file`
 `:file-download` `:subscriber` `:line-subscriber` `:buffering`
 `:replacing` `:lines`.
-
 
 ## Exceptional http statuses
 

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,8 @@
                  [exoscale/ex-auspex "0.3.17"]
                  [exoscale/ex-http "0.3.17"]
                  [cc.qbits/auspex "0.1.0-alpha4"]
-                 [cc.qbits/commons "1.0.0-alpha3"]]
+                 [cc.qbits/commons "1.0.0-alpha3"]
+                 [com.github.mizosoft.methanol/methanol "1.4.1"]]
   :profiles {:dev  {:dependencies [[ring/ring-jetty-adapter    "1.7.1"]]}
              :test {:dependencies []}}
   :plugins [[lein-cljfmt "0.7.0"]]

--- a/src/exoscale/telex/interceptor.clj
+++ b/src/exoscale/telex/interceptor.clj
@@ -29,7 +29,7 @@
                 :exoscale.telex/keys [request ^HttpClient client]}]
             (let [{:exoscale.telex.response/keys [executor]
                    :exoscale.telex.request/keys [async?]} ctx
-                  body-handler (response/body-handler ctx)]
+                  body-handler (response/make-body-handler ctx)]
               (if async?
                 (-> (.sendAsync client request body-handler)
                     (ax/then (fn [response]

--- a/src/exoscale/telex/response.clj
+++ b/src/exoscale/telex/response.clj
@@ -3,7 +3,9 @@
                           HttpResponse$BodyHandlers
                           HttpResponse$BodyHandler
                           HttpResponse$BodyHandlers)
-           java.nio.charset.Charset))
+           (java.nio.charset Charset)
+           (com.github.mizosoft.methanol MoreBodyHandlers)
+           (java.time Duration)))
 
 (defprotocol Response
   (status [http-response] "Returns http status of underlying response")
@@ -84,6 +86,13 @@
       (fn? bh) (bh)
       (instance? HttpResponse$BodyHandler bh) bh
       :else (HttpResponse$BodyHandlers/ofInputStream))))
+
+(defn make-body-handler
+  [{:as ctx :exoscale.telex.response.body-handler/keys [timeout]
+    :or {timeout 10000}}]
+  (cond-> (body-handler ctx)
+    (pos-int? timeout)
+    (MoreBodyHandlers/withReadTimeout (Duration/ofMillis timeout))))
 
 (defn headers->map
   [^HttpResponse http-response]

--- a/test/exoscale/telex/client_test.clj
+++ b/test/exoscale/telex/client_test.clj
@@ -1,16 +1,11 @@
 (ns exoscale.telex.client-test
   (:require [clojure.test :refer [deftest is use-fixtures]]
-            exoscale.ex.test
             [exoscale.ex :as ex]
-            [exoscale.telex.mocks :as mocks]
-            [exoscale.telex.interceptor :as ix]
-            [exoscale.telex.interceptor.ring1 :as r1]
-            [ring.util.io :as rio]
-            [clojure.java.io :as io]
+            exoscale.ex.test
             [exoscale.telex :as client]
-            [qbits.auspex :as ax]
-            [ring.core.protocols :as j])
-  (:import (java.io InputStream)))
+            [exoscale.telex.interceptor :as ix]
+            [exoscale.telex.mocks :as mocks]
+            [qbits.auspex :as ax]))
 
 (def ^:dynamic client)
 (def ^:dynamic request-opts)

--- a/test/exoscale/telex/client_test.clj
+++ b/test/exoscale/telex/client_test.clj
@@ -5,7 +5,12 @@
             [exoscale.telex.mocks :as mocks]
             [exoscale.telex.interceptor :as ix]
             [exoscale.telex.interceptor.ring1 :as r1]
-            [exoscale.telex :as client]))
+            [ring.util.io :as rio]
+            [clojure.java.io :as io]
+            [exoscale.telex :as client]
+            [qbits.auspex :as ax]
+            [ring.core.protocols :as j])
+  (:import (java.io InputStream)))
 
 (def ^:dynamic client)
 (def ^:dynamic request-opts)
@@ -14,89 +19,88 @@
 (use-fixtures :once
   (fn [t]
     (binding [client (client/client {})
-              request-opts (merge #:exoscale.telex.request{:async? false})
-              request #(client/request client (merge request-opts %))]
+              request #(client/request client %)]
       (t))))
 
 (deftest test-simple-requests-roundrip
-  (is (= 200 (:status (request {:method :get :url "http://google.com"}))))
+  (is (= 200 (:status @(request {:method :get :url "http://google.com"}))))
 
-  (is (= 200 (:status (request {:method :get :url "http://google.com"
-                                :exoscale.telex.request/version :http-2}))))
+  (is (= 200 (:status @(request {:method :get :url "http://google.com"
+                                 :exoscale.telex.request/version :http-2}))))
 
-  (is (= 200 (:status (request {:method :get :url "http://google.com"
-                                :exoscale.telex.request/version :http-1-1}))))
+  (is (= 200 (:status @(request {:method :get :url "http://google.com"
+                                 :exoscale.telex.request/version :http-1-1}))))
 
   (is (thrown? java.net.http.HttpTimeoutException
-               (request {:method :get :url "http://google.com"
-                         :exoscale.telex.request/timeout 1})))
+               (ax/unwrap (request {:method :get :url "http://google.com"
+                                    :exoscale.telex.request/timeout 1}))))
 
   (is (thrown-ex-info-type? :exoscale.ex/not-found
-                            (request {:method :get :url "http://google.com/404"}))
+                            (ax/unwrap (request {:method :get :url "http://google.com/404"})))
       "errors are mapped correctly for GET")
 
   (is (thrown-ex-info-type? :exoscale.ex/unsupported
-                            (request {:method :post :url "http://google.com"}))
+                            (ax/unwrap (request {:method :post :url "http://google.com"})))
       "errors are mapped correctly for GET")
 
-  (is (= 405 (:status (request {:method :post :url "http://google.com"
-                                :exoscale.telex.request/throw-on-error? false})))
+  (is (= 405 (:status @(request {:method :post :url "http://google.com"
+                                 :exoscale.telex.request/throw-on-error? false})))
       "disabling the throw interceptor"))
 
 (deftest test-body-handler
   (mocks/with-server 1234 (constantly {:status 200
                                        :body "Some value"})
-    (let [{:keys [status body]} (request {:method :get
-                                          :url "http://localhost:1234"
-                                          :exoscale.telex.response/body-handler :string})]
+    (let [{:keys [status body]} @(request {:method :get
+                                           :url "http://localhost:1234"
+                                           :exoscale.telex.response/body-handler :string})]
       (is (= 200 status))
       (is (= "Some value" body)))))
 
 (deftest test-post-body
   (mocks/with-server 1234 (fn [{:keys [body]}] {:status 200 :body body})
     (let [{:keys [status body]}
-          (request {:method :post
-                    :url "http://localhost:1234"
-                    :exoscale.telex.response/body-handler :string
-                    :body "abc"})]
+          @(request {:method :post
+                     :url "http://localhost:1234"
+                     :exoscale.telex.response/body-handler :string
+                     :body "abc"})]
       (is (= 200 status))
       (is (= "abc" body)))))
 
 (deftest test-post-form-params
   (mocks/with-server 1234 (fn [{:keys [body]}] {:status 200 :body body})
     (let [{:keys [status body]}
-          (request {:method :post
-                    :url "http://localhost:1234"
-                    :exoscale.telex.response/body-handler :string
-                    :form-params {:a 1}})]
+          @(request {:method :post
+                     :url "http://localhost:1234"
+                     :exoscale.telex.response/body-handler :string
+                     :form-params {:a 1}})]
       (is (= 200 status))
       (is (= "a=1" body)))
 
     (let [{:keys [status body]}
-          (request {:method :post
-                    :url "http://localhost:1234"
-                    :exoscale.telex.response/body-handler :string
-                    :form-params {}})]
+          @(request {:method :post
+                     :url "http://localhost:1234"
+                     :exoscale.telex.response/body-handler :string
+                     :form-params {}})]
       (is (= 200 status))
       (is (= "" body)))))
 
 (deftest test-post-form-params+body
   (mocks/with-server 1234 (fn [{:keys [body]}] {:status 200 :body body})
     (let [{:keys [status body]}
-          (request {:method :post
-                    :url "http://localhost:1234"
-                    :exoscale.telex.response/body-handler :string
-                    :form-params {:a 1}
-                    :body "a"})]
+          @(request {:method :post
+                     :url "http://localhost:1234"
+                     :exoscale.telex.response/body-handler :string
+                     :form-params {:a 1}
+                     :body "a"})]
       (is (= 200 status))
       (is (= "a" body) "body always takes over if specified"))
 
     (let [{:keys [status body]}
-          (request {:method :post
-                    :url "http://localhost:1234"
-                    :exoscale.telex.response/body-handler :string
-                    :form-params {}
-                    :body "a"})]
+          @(request {:method :post
+                     :url "http://localhost:1234"
+                     :exoscale.telex.response/body-handler :string
+                     :form-params {}
+                     :body "a"})]
       (is (= 200 status))
       (is (= "a" body)))))
 
@@ -104,12 +108,35 @@
   (mocks/with-server 1234 (constantly {:status 400
                                        :body "Invalid"})
     (ex/try+
-     (request {:method :get
-               :url "http://localhost:1234"
-               :exoscale.telex.response/body-handler :string})
-     (catch :exoscale.ex/incorrect {{:keys [status body]} :response}
-       (is (= status 400))
-       (is (= body "Invalid"))))))
+      (ax/unwrap
+       (request {:method :get
+                 :url "http://localhost:1234"
+                 :exoscale.telex.response/body-handler :string}))
+      (catch :exoscale.ex/incorrect {{:keys [status body]} :response}
+        (is (= status 400))
+        (is (= body "Invalid"))))))
+
+(deftest test-response-body-read-timeout
+  (is (thrown? java.net.http.HttpTimeoutException
+               (ax/unwrap (request {:method :get
+                                    :url "https://releases.ubuntu.com/20.04.2.0/ubuntu-20.04.2.0-desktop-amd64.iso"
+                                    :exoscale.telex.response/body-handler :string
+                                    :exoscale.telex.response.body-handler/timeout 100})))
+      "when we try to realize we will get the actual exception")
+  (is (thrown? java.io.IOException
+               (-> @(request {:method :get
+                              :url "https://releases.ubuntu.com/20.04.2.0/ubuntu-20.04.2.0-desktop-amd64.iso"
+                              :exoscale.telex.response.body-handler/timeout 100})
+                   :body
+                   slurp))
+      "input stream will just close in that case, HttpReadTimeoutException will be in cause, IOE is root")
+  (mocks/with-server 1234 (constantly {:status 200
+                                       :body "ok"})
+    (is (seq (slurp (:body @(request {:method :get
+                                      :url "http://localhost:1234"
+                                      :exoscale.telex.response/body-handler :input-stream
+                                      :exoscale.telex.response.body-handler/timeout 3000}))))
+        "we got content before timeout")))
 
 (deftest params-test
   (is (= "a=1&b=2" (ix/encode-query-params {:a 1 :b 2})))

--- a/test/exoscale/telex/client_test.clj
+++ b/test/exoscale/telex/client_test.clj
@@ -116,12 +116,12 @@
                (ax/unwrap (request {:method :get
                                     :url "https://releases.ubuntu.com/20.04.2.0/ubuntu-20.04.2.0-desktop-amd64.iso"
                                     :exoscale.telex.response/body-handler :string
-                                    :exoscale.telex.response.body-handler/timeout 100})))
+                                    :exoscale.telex.response.body-handler/timeout 10})))
       "when we try to realize we will get the actual exception")
   (is (thrown? java.io.IOException
                (-> @(request {:method :get
                               :url "https://releases.ubuntu.com/20.04.2.0/ubuntu-20.04.2.0-desktop-amd64.iso"
-                              :exoscale.telex.response.body-handler/timeout 100})
+                              :exoscale.telex.response.body-handler/timeout 10})
                    :body
                    slurp))
       "input stream will just close in that case, HttpReadTimeoutException will be in cause, IOE is root")

--- a/test/exoscale/telex/client_test.clj
+++ b/test/exoscale/telex/client_test.clj
@@ -108,13 +108,13 @@
   (mocks/with-server 1234 (constantly {:status 400
                                        :body "Invalid"})
     (ex/try+
-      (ax/unwrap
-       (request {:method :get
-                 :url "http://localhost:1234"
-                 :exoscale.telex.response/body-handler :string}))
-      (catch :exoscale.ex/incorrect {{:keys [status body]} :response}
-        (is (= status 400))
-        (is (= body "Invalid"))))))
+     (ax/unwrap
+      (request {:method :get
+                :url "http://localhost:1234"
+                :exoscale.telex.response/body-handler :string}))
+     (catch :exoscale.ex/incorrect {{:keys [status body]} :response}
+       (is (= status 400))
+       (is (= body "Invalid"))))))
 
 (deftest test-response-body-read-timeout
   (is (thrown? java.net.http.HttpTimeoutException


### PR DESCRIPTION
Added a way to get read timeout from reading response bodies via methanol. I also added a default read timeout of 10s. 

